### PR TITLE
Localizable strings fix

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -31,6 +31,7 @@ Freecell_RESOURCE_FILES=\
 
 Freecell_LOCALIZED_RESOURCE_FILES=\
         MainMenu.nib\
+        Localizable.strings\
         Credits.html
 
 Freecell_LANGUAGES=\


### PR DESCRIPTION
The GNUmakefile didn't include the file localizable.strings into the app bundle, so the main window title and some dialogs had some broken text